### PR TITLE
Add missing source files to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demvsystems/yup-ast",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Rewrite of the original yup-ast due to licensing problems. Converts JSON into yup objects.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,6 +46,7 @@
     "husky": "^4.2.3",
     "jest": "^25.1.0",
     "semantic-release": "^17.0.4",
+    "sourcemap-validator": "^2.1.0",
     "ts-jest": "^25.2.1",
     "typescript": "^3.8.3"
   },
@@ -53,6 +54,7 @@
     "yup": "^0.28.3"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "src/*.ts"
   ]
 }

--- a/src/__tests__/sourceMap.test.ts
+++ b/src/__tests__/sourceMap.test.ts
@@ -1,0 +1,14 @@
+import validate from 'sourcemap-validator';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const BASE_PATH = join(__dirname, '..', '..');
+
+const distCode = readFileSync(join(BASE_PATH, '/dist/index.js'), { encoding: 'utf-8' });
+const distCodeMap = readFileSync(join(BASE_PATH, '/dist/index.js.map'), { encoding: 'utf-8' });
+
+describe('source map for distribution', () => {
+  it('builds a valid source map', () => {
+    expect(() => validate(distCode, distCodeMap)).not.toThrow();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,6 +1275,11 @@ ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
+
 ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -4465,6 +4470,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+jsesc@~0.3.x:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.3.0.tgz#1bf5ee63b4539fe2e26d0c1e99c240b97a457972"
+  integrity sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -4757,6 +4767,11 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -4782,7 +4797,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.template@^4.0.2:
+lodash.template@^4.0.2, lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
   integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
@@ -6680,6 +6695,23 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+source-map@~0.1.x:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
+
+sourcemap-validator@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sourcemap-validator/-/sourcemap-validator-2.1.0.tgz#5f698e0b013fc550ed81df740034f52556555b1c"
+  integrity sha512-87aDeWwPT6Flaz6fJQdXmTmW2uZ1kebAthB3i2NmCZzAFkJtNpUm6vqIs5SGO44L92W8WpewkdBwVgNPvZeT+Q==
+  dependencies:
+    jsesc "~0.3.x"
+    lodash.foreach "^4.5.0"
+    lodash.template "^4.5.0"
+    source-map "~0.1.x"
 
 spawn-error-forwarder@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Based on the decision of [CRA](https://github.com/facebook/create-react-app/pull/8227) we decided we want to provide more value to the developers with our source map and include the sources in the package as well now.
This increases the size a little bit in the `node_modules` folder, but not that much that it would be a concern.

Also I included a test based on the `sourcemap-validator` package to check that our source map is valid.

This also solves #23 